### PR TITLE
Fix typo in coredns config

### DIFF
--- a/docs/getting_started/kubernetes_on_ubuntu_ce.md
+++ b/docs/getting_started/kubernetes_on_ubuntu_ce.md
@@ -126,7 +126,7 @@ data:
           fallthrough in-addr.arpa ip6.arpa
         }
         prometheus :9153
-        forward . <Fill your own DSN server>
+        forward . <Fill your own DNS server>
         cache 30
         loop
         reload

--- a/docs/getting_started/kubernetes_on_ubuntu_machine.md
+++ b/docs/getting_started/kubernetes_on_ubuntu_machine.md
@@ -124,7 +124,7 @@ data:
           fallthrough in-addr.arpa ip6.arpa
         }
         prometheus :9153
-        forward . <Fill your own DSN server>
+        forward . <Fill your own DNS server>
         cache 30
         loop
         reload

--- a/website/versioned_docs/version-3.0/getting_started/kubernetes_on_ubuntu_machine.md
+++ b/website/versioned_docs/version-3.0/getting_started/kubernetes_on_ubuntu_machine.md
@@ -124,7 +124,7 @@ data:
           fallthrough in-addr.arpa ip6.arpa
         }
         prometheus :9153
-        forward . <Fill your own DSN server>
+        forward . <Fill your own DNS server>
         cache 30
         loop
         reload

--- a/website/versioned_docs/version-3.2/getting_started/kubernetes_on_ubuntu_ce.md
+++ b/website/versioned_docs/version-3.2/getting_started/kubernetes_on_ubuntu_ce.md
@@ -126,7 +126,7 @@ data:
           fallthrough in-addr.arpa ip6.arpa
         }
         prometheus :9153
-        forward . <Fill your own DSN server>
+        forward . <Fill your own DNS server>
         cache 30
         loop
         reload

--- a/website/versioned_docs/version-3.4/getting_started/kubernetes_on_ubuntu_ce.md
+++ b/website/versioned_docs/version-3.4/getting_started/kubernetes_on_ubuntu_ce.md
@@ -127,7 +127,7 @@ data:
           fallthrough in-addr.arpa ip6.arpa
         }
         prometheus :9153
-        forward . <Fill your own DSN server>
+        forward . <Fill your own DNS server>
         cache 30
         loop
         reload

--- a/website/versioned_docs/version-3.4/getting_started/kubernetes_on_ubuntu_machine.md
+++ b/website/versioned_docs/version-3.4/getting_started/kubernetes_on_ubuntu_machine.md
@@ -125,7 +125,7 @@ data:
           fallthrough in-addr.arpa ip6.arpa
         }
         prometheus :9153
-        forward . <Fill your own DSN server>
+        forward . <Fill your own DNS server>
         cache 30
         loop
         reload

--- a/website/versioned_docs/version-3.5/getting_started/kubernetes_on_ubuntu_ce.md
+++ b/website/versioned_docs/version-3.5/getting_started/kubernetes_on_ubuntu_ce.md
@@ -127,7 +127,7 @@ data:
           fallthrough in-addr.arpa ip6.arpa
         }
         prometheus :9153
-        forward . <Fill your own DSN server>
+        forward . <Fill your own DNS server>
         cache 30
         loop
         reload

--- a/website/versioned_docs/version-3.5/getting_started/kubernetes_on_ubuntu_machine.md
+++ b/website/versioned_docs/version-3.5/getting_started/kubernetes_on_ubuntu_machine.md
@@ -125,7 +125,7 @@ data:
           fallthrough in-addr.arpa ip6.arpa
         }
         prometheus :9153
-        forward . <Fill your own DSN server>
+        forward . <Fill your own DNS server>
         cache 30
         loop
         reload

--- a/website/versioned_docs/version-3.6/getting_started/kubernetes_on_ubuntu_ce.md
+++ b/website/versioned_docs/version-3.6/getting_started/kubernetes_on_ubuntu_ce.md
@@ -128,7 +128,7 @@ data:
           fallthrough in-addr.arpa ip6.arpa
         }
         prometheus :9153
-        forward . <Fill your own DSN server>
+        forward . <Fill your own DNS server>
         cache 30
         loop
         reload

--- a/website/versioned_docs/version-3.6/getting_started/kubernetes_on_ubuntu_machine.md
+++ b/website/versioned_docs/version-3.6/getting_started/kubernetes_on_ubuntu_machine.md
@@ -126,7 +126,7 @@ data:
           fallthrough in-addr.arpa ip6.arpa
         }
         prometheus :9153
-        forward . <Fill your own DSN server>
+        forward . <Fill your own DNS server>
         cache 30
         loop
         reload


### PR DESCRIPTION
Signed-off-by: Timothy Lee <ctiml@infuseai.io>

Fix typo `DSN` -> `DNS`